### PR TITLE
Move to optree

### DIFF
--- a/examples/yelp/yelp_vi_diag.py
+++ b/examples/yelp/yelp_vi_diag.py
@@ -2,6 +2,7 @@ import torch
 from torch.distributions import Normal, Categorical
 from torchopt import adamw
 from tqdm.auto import tqdm
+from optree import tree_map
 
 import uqlib
 
@@ -49,7 +50,7 @@ def param_to_log_posterior(p, batch):
 
 
 init_mean = dict(model.named_parameters())
-init_log_sds = uqlib.tree_map(
+init_log_sds = tree_map(
     lambda x: (torch.zeros_like(x) - 2.0).requires_grad_(True), init_mean
 )
 
@@ -79,7 +80,7 @@ for epoch in range(num_epochs):
 
 
 # mu = dict(model.named_parameters())
-# log_sigma = uqlib.tree_map(lambda x: torch.zeros_like(x, requires_grad=True), mu)
+# log_sigma = tree_map(lambda x: torch.zeros_like(x, requires_grad=True), mu)
 
 # vi_params_tensors = list(mu.values()) + list(log_sigma.values())
 
@@ -101,7 +102,7 @@ for epoch in range(num_epochs):
 #         batch = {k: v.to(device) for k, v in batch.items()}
 #         vi_optimizer.zero_grad()
 
-#         sigma = uqlib.tree_map(torch.exp, log_sigma)
+#         sigma = tree_map(torch.exp, log_sigma)
 
 #         nelbo = uqlib.vi.diag.nelbo(
 #             mu,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Mathematics",
     "License :: OSI Approved :: Apache Software License",
 ]
-dependencies = ["torch>=2.0.0", "torchopt>=0.7.3"]
+dependencies = ["torch>=2.0.0", "torchopt>=0.7.3", "optree>=0.10.0"]
 
 [tool.setuptools]
 packages = ["uqlib"]

--- a/tests/laplace/test_diag_fisher.py
+++ b/tests/laplace/test_diag_fisher.py
@@ -4,8 +4,8 @@ import torch.nn as nn
 from torch.distributions import Normal
 from torch.utils.data import DataLoader, TensorDataset
 from torch.func import functional_call
+from optree import tree_map
 
-from uqlib import tree_map
 from uqlib.laplace import diag_fisher
 
 
@@ -44,6 +44,7 @@ def log_posterior_n(params, batch, model, n_data):
 
 
 def test_diag_fisher():
+    torch.manual_seed(42)
     model = TestModel()
 
     xs = torch.randn(100, 10)

--- a/tests/laplace/test_diag_hessian.py
+++ b/tests/laplace/test_diag_hessian.py
@@ -4,8 +4,9 @@ import torch.nn as nn
 from torch.distributions import Normal
 from torch.utils.data import DataLoader, TensorDataset
 from torch.func import functional_call
+from optree import tree_map
 
-from uqlib import tree_map, hessian_diag
+from uqlib import hessian_diag
 from uqlib.laplace import diag_hessian
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,10 +1,8 @@
 import torch
 import torch.nn as nn
-
+from optree import tree_map
 
 from uqlib import (
-    tree_map,
-    tree_reduce,
     hessian_diag,
     model_to_function,
     diag_normal_log_prob,
@@ -37,51 +35,6 @@ class TestLanguageModel(nn.Module):
         expanded_attention_mask = attention_mask.unsqueeze(-1).expand(logits.size())
         logits = logits * expanded_attention_mask
         return {"logits": logits}
-
-
-def test_tree_map():
-    t1 = (1, 2)
-    t2 = (3, 4)
-    result = tree_map(lambda x, y: x + y, t1, t2)
-    assert result == (4, 6)
-
-    d1 = {"a": 1, "b": 2}
-    d2 = {"a": 3, "b": 4}
-    result = tree_map(lambda x, y: x + y, d1, d2)
-    assert result == {"a": 4, "b": 6}
-
-    # This test breaks as torch just treats the list as a tensor,
-    # this may be desired behaviour
-    # d1 = {"a": 10, "b": [1, 2]}
-    # d2 = {"a": 20, "b": [3, 4]}
-    # result = tree_map(lambda x, y: x + y, d1, d2)
-    # assert result == {"a": 30, "b": [1, 2, 3, 4]}
-
-    d1 = {"a": torch.tensor([1, 2]), "b": torch.tensor([3, 4])}
-    d2 = {"a": torch.tensor([5, 6]), "b": torch.tensor([7, 8])}
-    result = tree_map(torch.add, d1, d2)
-    expected = {"a": torch.tensor([6, 8]), "b": torch.tensor([10, 12])}
-    for key in result:
-        assert torch.equal(result[key], expected[key])
-
-
-def test_tree_reduce():
-    t = (1, 2, 3, 4)
-    result = tree_reduce(lambda x, y: x + y, t)
-    result2 = tree_reduce(torch.add, t)
-    assert result == 10
-    assert result2 == 10
-
-    d = {"a": 1, "b": 2, "c": 3, "d": 4}
-    result = tree_reduce(lambda x, y: x + y, d)
-    result2 = tree_reduce(torch.add, t)
-    assert result == 10
-    assert result2 == 10
-
-    d = {"a": torch.tensor([1, 2]), "b": torch.tensor([3, 4])}
-    result = tree_reduce(torch.add, d)
-    expected = torch.tensor([4, 6])
-    assert torch.equal(result, expected)
 
 
 def test_model_to_function():

--- a/tests/vi/test_diag.py
+++ b/tests/vi/test_diag.py
@@ -2,9 +2,10 @@ from functools import partial
 from typing import Any
 import torch
 import torchopt
+from optree import tree_map
 
 from uqlib import vi
-from uqlib.utils import tree_map, diag_normal_log_prob
+from uqlib.utils import diag_normal_log_prob
 
 
 def batch_normal_log_prob(

--- a/uqlib/__init__.py
+++ b/uqlib/__init__.py
@@ -1,8 +1,6 @@
 from . import laplace
 from . import vi
 
-from .utils import tree_map
-from .utils import tree_reduce
 from .utils import model_to_function
 from .utils import hvp
 from .utils import hessian_diag

--- a/uqlib/laplace/diag_fisher.py
+++ b/uqlib/laplace/diag_fisher.py
@@ -2,8 +2,9 @@ from functools import partial
 from typing import Callable, Any, NamedTuple
 import torch
 from torch.func import jacrev, vmap
+from optree import tree_map
 
-from uqlib.utils import tree_map, diag_normal_sample
+from uqlib.utils import diag_normal_sample
 
 
 class DiagLaplaceState(NamedTuple):

--- a/uqlib/laplace/diag_hessian.py
+++ b/uqlib/laplace/diag_hessian.py
@@ -1,8 +1,8 @@
 from typing import Callable, Any
 import torch
-from torch.utils._pytree import tree_flatten
+from optree import tree_map, tree_flatten
 
-from uqlib.utils import hessian_diag, tree_map, diag_normal_sample
+from uqlib.utils import hessian_diag, diag_normal_sample
 from uqlib.laplace.diag_fisher import DiagLaplaceState
 
 

--- a/uqlib/vi/diag.py
+++ b/uqlib/vi/diag.py
@@ -1,9 +1,10 @@
 from typing import Callable, Any, NamedTuple
 import torch
 from torch.func import grad_and_value, vmap
+from optree import tree_map
 import torchopt
 
-from uqlib.utils import tree_map, diag_normal_log_prob, diag_normal_sample
+from uqlib.utils import diag_normal_log_prob, diag_normal_sample
 
 
 class VIDiagState(NamedTuple):


### PR DESCRIPTION
Remove `uqlib.tree_map` and `uqlib.tree_reduce` in favour of the `optree` versions which have the same API.

After the next `torch` release we can probably remove the `optree` dependency too and just use `torch.utils._pytree` although this isn't technically user facing yet so we might want to stick with `optree` until `torch.utils._pytree` becomes `torch.utils.pytree` 😄 