### PR TITLE
Remove import warning from torchopt

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,4 +24,4 @@ packages = ["uqlib"]
 
 [tool.ruff]
 [tool.ruff.lint.per-file-ignores]
-"__init__.py" = ["F401", "F821"]
+"__init__.py" = ["F401", "F821", "E402"]

--- a/uqlib/__init__.py
+++ b/uqlib/__init__.py
@@ -2,9 +2,8 @@ from uqlib import ekf
 from uqlib import laplace
 from uqlib import sgmcmc
 from uqlib import types
-from uqlib import vi
 from uqlib import optim
-from uqlib import torchopt
+
 
 from uqlib.utils import model_to_function
 from uqlib.utils import linearized_forward_diag
@@ -23,3 +22,15 @@ from uqlib.utils import inplacify
 from uqlib.utils import tree_map_inplacify_
 from uqlib.utils import flexi_tree_map
 from uqlib.utils import per_samplify
+
+
+import logging
+
+logger = logging.getLogger("torch.distributed.elastic.multiprocessing.redirects")
+logger.setLevel(logging.ERROR)
+
+from uqlib import vi
+from uqlib import torchopt
+
+del logging
+del logger


### PR DESCRIPTION
This PR removes the annoying warning you get on `import uqlib` for Mac or Windows. The warning arises from annoying `torchopt` code and also occurs when you do `import torchopt`.

The added code only surpresses warnings from `torch.distributed.elastic.multiprocessing.redirects` and not any others, which seems fairly safe.

The solution also meant running code before some imports in the `__init__.py`, this meant we had to tell Ruff to ignore the E402 warning (Module level import not at top of file) for the `__init__.py`.

This is the best solution I came up with, but I'm open to suggestions!