### PR TITLE
Add TransformState to optree registry

### DIFF
--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,0 +1,32 @@
+import torch
+from dataclasses import dataclass
+import optree
+
+from uqlib.types import TransformState
+
+
+def test_TransformState():
+    @dataclass
+    class s(TransformState):
+        params: torch.Tensor
+        aux: torch.Tensor
+        b: dict
+
+    a = s(torch.ones(3), aux=torch.ones(3), b={"tens": torch.ones(3)})
+
+    children, metadata = optree.tree_flatten(a)
+
+    assert len(children) == 3
+    assert len(metadata) == 3
+
+    a2 = optree.tree_unflatten(metadata, children)
+    children2, metadata2 = optree.tree_flatten(a2)
+
+    for i, j in zip(children, children2):
+        assert torch.allclose(i, j)
+
+    y = optree.tree_map(lambda x: x * 2, a)
+    children_y, metadata_y = optree.tree_flatten(y)
+
+    for i, j in zip(children, children_y):
+        assert torch.allclose(i * 2, j)

--- a/uqlib/ekf/diag_fisher.py
+++ b/uqlib/ekf/diag_fisher.py
@@ -5,12 +5,12 @@ from torch.func import jacrev
 from optree import tree_map
 from dataclasses import dataclass
 
-from uqlib.types import TensorTree, Transform, LogProbFn
+from uqlib.types import TensorTree, Transform, LogProbFn, TransformState
 from uqlib.utils import diag_normal_sample, flexi_tree_map, per_samplify, is_scalar
 
 
 @dataclass
-class EKFDiagState:
+class EKFDiagState(TransformState):
     """State encoding a diagonal Normal distribution over parameters.
 
     Args:

--- a/uqlib/laplace/dense_fisher.py
+++ b/uqlib/laplace/dense_fisher.py
@@ -5,12 +5,12 @@ import torch
 from optree import tree_map
 from optree.integration.torch import tree_ravel
 
-from uqlib.types import TensorTree, Transform, LogProbFn, Tensor
+from uqlib.types import TensorTree, Transform, LogProbFn, Tensor, TransformState
 from uqlib.utils import per_samplify, tree_size, empirical_fisher, is_scalar
 
 
 @dataclass
-class DenseLaplaceState:
+class DenseLaplaceState(TransformState):
     """State encoding a Normal distribution over parameters,
     with a dense precision matrix
 

--- a/uqlib/laplace/diag_fisher.py
+++ b/uqlib/laplace/diag_fisher.py
@@ -5,12 +5,12 @@ from torch.func import jacrev
 from optree import tree_map
 from dataclasses import dataclass
 
-from uqlib.types import TensorTree, Transform, LogProbFn
+from uqlib.types import TensorTree, Transform, LogProbFn, TransformState
 from uqlib.utils import diag_normal_sample, flexi_tree_map, per_samplify, is_scalar
 
 
 @dataclass
-class DiagLaplaceState:
+class DiagLaplaceState(TransformState):
     """State encoding a diagonal Normal distribution over parameters.
 
     Args:

--- a/uqlib/sgmcmc/sghmc.py
+++ b/uqlib/sgmcmc/sghmc.py
@@ -5,12 +5,12 @@ from torch.func import grad_and_value
 from optree import tree_map
 from dataclasses import dataclass
 
-from uqlib.types import TensorTree, Transform, LogProbFn
+from uqlib.types import TensorTree, Transform, LogProbFn, TransformState
 from uqlib.utils import flexi_tree_map, is_scalar
 
 
 @dataclass
-class SGHMCState:
+class SGHMCState(TransformState):
     """State encoding params and momenta for SGHMC.
 
     Args:

--- a/uqlib/vi/diag.py
+++ b/uqlib/vi/diag.py
@@ -6,12 +6,12 @@ from optree import tree_map
 import torchopt
 from dataclasses import dataclass
 
-from uqlib.types import TensorTree, Transform, LogProbFn
+from uqlib.types import TensorTree, Transform, LogProbFn, TransformState
 from uqlib.utils import diag_normal_log_prob, diag_normal_sample, is_scalar
 
 
 @dataclass
-class VIDiagState:
+class VIDiagState(TransformState):
     """State encoding a diagonal Normal variational distribution over parameters.
 
     Args:


### PR DESCRIPTION
Bit of fiddly PR this one.

I've added code that adds TransformState to the optree PyNode registry so that it classes that inherit `TransformState` work with `optree.tree_flatten` and `optree.tree_map`.

Previously we used `NamedTuple` which was [supported by default by optree](https://github.com/metaopt/optree?tab=readme-ov-file#built-in-pytree-node-types) but `dataclass` isn't so we have to add it manually.

Note that not supporting `tree_map` didn't actually break any code as most code acted directly on e.g. `state.params` but it is still a nice to have so we can do things like `state = tree_map(lambda x: x.to(device), state)`