### PR TITLE
Change `empirical_fisher` API to match `torch.func.jacrev`

### DIFF
--- a/posteriors/laplace/dense_fisher.py
+++ b/posteriors/laplace/dense_fisher.py
@@ -79,7 +79,9 @@ def update(
         log_posterior = per_samplify(log_posterior)
 
     with torch.no_grad():
-        fisher, aux = empirical_fisher(log_posterior, state.params, batch)
+        fisher, aux = empirical_fisher(lambda p: log_posterior(p, batch), has_aux=True)(
+            state.params
+        )
 
     if inplace:
         state.prec += fisher

--- a/tests/laplace/test_dense_fisher.py
+++ b/tests/laplace/test_dense_fisher.py
@@ -58,7 +58,9 @@ def test_dense_fisher_vmap():
         x = x.unsqueeze(0)
         y = y.unsqueeze(0)
         with torch.no_grad():
-            fisher = empirical_fisher(log_posterior_per_sample, params, (x, y))[0]
+            fisher = empirical_fisher(
+                lambda p: log_posterior_per_sample(p, (x, y)), has_aux=True
+            )(params)[0]
 
         expected += fisher
 


### PR DESCRIPTION
This unifies the `empirical_fisher` to match the `torch.func` API, which is also more flexible.

I also moved `empirical_fisher` to be next to `fvp` in the `utils` file