### PR TITLE
Move build to top

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -15,7 +15,9 @@ cd posteriors
 pip install -e '.[test, docs]'
 pre-commit install
 ```
-3. **Add your code. Add your tests. Update the docs if needed. Party on!**
+3. **Add your code. Add your tests. Update the docs if needed. Party on!**  
+    New methods should list `build`, `state`, `init` and `update`
+    at the top of the module in order.
 4. Make sure to run the tests and linter:
 ```
 python -m pytest

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -64,6 +64,8 @@ Here:
 - `build` is a function that loads `config_args` into the `init` and `update` functions
  and stores them within the `transform` instance. The `init` and `update` 
  functions then conform to a preset signature allowing for easy switching between algorithms.
+- `state` is a [`dataclass`](https://docs.python.org/3/library/dataclasses.html)
+    encoding the state of the algorithm, including `params` and `aux` attributes.
 - `init` constructs the iteration-varying `state` based on the model parameters `params`.
 - `update` updates the `state` based on a new `batch` of data.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -32,6 +32,7 @@ plugins:
         python:
           options:
             members_order: source
+            group_by_category: false
             show_root_toc_entry: false
             show_root_members_full_path: true
 


### PR DESCRIPTION
This PR does not change any code. It only moves the `build` function to the top of each of the methods modules.

Having `build` at the top means the algorithm specific configuration arguments are visible right at the top of the code and the docs which imo is useful for the user.

In a subsequent PR I will go through and improve the docstrings including a proper description and references for each algorithm in each `build` function so that this is also immediately visible.

I've also added a little comment in the contributing page mentioning the `build`, `state`, `init`, `update` ordering of methods modules.