### PR TITLE
Add support for conjugate gradient solver through callable matrix-vector products

### DIFF
--- a/posteriors/__init__.py
+++ b/posteriors/__init__.py
@@ -10,6 +10,7 @@ from posteriors.utils import linearized_forward_diag
 from posteriors.utils import hvp
 from posteriors.utils import fvp
 from posteriors.utils import empirical_fisher
+from posteriors.utils import cg
 from posteriors.utils import diag_normal_log_prob
 from posteriors.utils import diag_normal_sample
 from posteriors.utils import tree_size

--- a/posteriors/utils.py
+++ b/posteriors/utils.py
@@ -230,10 +230,16 @@ def empirical_fisher(
     return fisher
 
 
-def _vdot_real_part(x, y):
+def _vdot_real_part(x: Tensor, y: Tensor) -> float:
     """Vector dot-product guaranteed to have a real valued result despite
     possibly complex input. Thus neglects the real-imaginary cross-terms.
-    The result is a real float.
+
+    Args:
+        x: First tensor in the dot product.
+        y: Second tensor in the dot product.
+
+    Returns:
+        The result vector dot-product, a real float
     """
     # all our uses of vdot() in CG are for computing an operator of the form
     #  z^H M z
@@ -247,11 +253,11 @@ def _vdot_real_part(x, y):
     return real_part
 
 
-def _vdot_real_tree(x, y):
+def _vdot_real_tree(x, y) -> TensorTree:
     return sum(tree_leaves(tree_map(_vdot_real_part, x, y)))
 
 
-def _mul(scalar, tree):
+def _mul(scalar, tree) -> TensorTree:
     return tree_map(partial(operator.mul, scalar), tree)
 
 
@@ -270,7 +276,7 @@ def cg(
     tol: Tensor = torch.Tensor([1e-5]),
     atol: Tensor = torch.Tensor([0]),
     M: Callable = _identity,
-):
+) -> Tuple[TensorTree, Any]:
     """Use Conjugate Gradient iteration to solve ``Ax = b``.
     ``A`` is suplied as a function instead of a sparse
     matrix or ``LinearOperator``.
@@ -278,7 +284,7 @@ def cg(
     Derivatives of ``cg`` are implemented via implicit differentiation with
     another ``cg`` solve, rather than by differentiating *through* the solver.
     They will be accurate only if both solves converge.
-    Adapted from
+    Adapted from https://jax.readthedocs.io/en/latest/_autosummary/jax.scipy.sparse.linalg.cg.html.
 
     Args:
 

--- a/posteriors/utils.py
+++ b/posteriors/utils.py
@@ -331,11 +331,11 @@ def cg(
     def body_fun(value):
         x, r, gamma, p, k = value
         Ap = A_damped(p)
-        alpha = gamma / _vdot_real_tree(p, Ap)  # .astype(dtype)
+        alpha = gamma / _vdot_real_tree(p, Ap)  
         x_ = _add(x, _mul(alpha, p))
         r_ = _sub(r, _mul(alpha, Ap))
         z_ = M(r_)
-        gamma_ = _vdot_real_tree(r_, z_)  # .astype(dtype)
+        gamma_ = _vdot_real_tree(r_, z_) 
         beta_ = gamma_ / gamma
         p_ = _add(z_, _mul(beta_, p))
         return x_, r_, gamma_, p_, k + 1

--- a/posteriors/utils.py
+++ b/posteriors/utils.py
@@ -273,7 +273,6 @@ def cg(
     A: Callable,
     b: TensorTree,
     x0: TensorTree = None,
-    *,
     maxiter: int = None,
     damping: float = 0.0,
     tol: float = 1e-5,
@@ -283,33 +282,28 @@ def cg(
     """Use Conjugate Gradient iteration to solve ``Ax = b``.
     ``A`` is supplied as a function instead of a matrix.
 
-    Derivatives of ``cg`` are implemented via implicit differentiation with
-    another ``cg`` solve, rather than by differentiating *through* the solver.
-    They will be accurate only if both solves converge.
-    Adapted from https://jax.readthedocs.io/en/latest/_autosummary/jax.scipy.sparse.linalg.cg.html
+    Adapted from [`jax.scipy.sparse.linalg.cg`](https://jax.readthedocs.io/en/latest/_autosummary/jax.scipy.sparse.linalg.cg.html).
 
-    Args:
-
+    Args: 
         A:  Callable that calculates the linear map (matrix-vector
             product) ``Ax`` when called like ``A(x)``. ``A`` must represent
             a hermitian, positive definite matrix, and must return array(s) with the
             same structure and shape as its argument.
-        b : Right hand side of the linear system representing a single vector.
-        x0 : Starting guess for the solution. Must have the same structure as ``b``.
-        tol, atol : Tolerances for convergence, ``norm(residual) <= max(tol*norm(b), atol)``.
-            The behaviour will differ from SciPy unless you explicitly pass
-            ``atol`` to SciPy's ``cg``.
+        b:  Right hand side of the linear system representing a single vector.
+        x0: Starting guess for the solution. Must have the same structure as ``b``.
         maxiter : Maximum number of iterations.  Iteration will stop after maxiter
             steps even if the specified tolerance has not been achieved.
+        damping : damping term for the mvp function. Acts as regularization.
+        tol: Tolerance for convergence.
+        atol: Tolerance for convergence. ``norm(residual) <= max(tol*norm(b), atol)``.
+            The behaviour will differ from SciPy unless you explicitly pass
+            ``atol`` to SciPy's ``cg``.
         M : Preconditioner for A.
             See https://en.wikipedia.org/wiki/Conjugate_gradient_method#The_preconditioned_conjugate_gradient_method
 
-    Returns
-        x : array or tree of arrays
-            The converged solution. Has the same structure as ``b``.
-        info : Placeholder for convergence information. In the future, JAX will report
-            the number of iterations when convergence is not achieved, like SciPy.
-
+    Returns:
+        x : The converged solution. Has the same structure as ``b``.
+        info : Placeholder for convergence information. 
     """
     if x0 is None:
         x0 = tree_map(torch.zeros_like, b)

--- a/posteriors/utils.py
+++ b/posteriors/utils.py
@@ -5,7 +5,7 @@ import contextlib
 import torch
 from torch.func import grad, jvp, vjp, functional_call, jacrev
 from torch.distributions import Normal
-from optree import tree_map, tree_map_, tree_reduce, tree_flatten, tree_leaves, Partial
+from optree import tree_map, tree_map_, tree_reduce, tree_flatten, tree_leaves
 from optree.integration.torch import tree_ravel
 
 
@@ -240,10 +240,11 @@ def _vdot_real_part(x, y):
     #  where M is positive definite and Hermitian, so the result is
     # real valued:
     # https://en.wikipedia.org/wiki/Definiteness_of_a_matrix#Definitions_for_complex_matrices
-    result = torch.vdot(x.real, y.real)
+    real_part = torch.einsum("...i,...i->...", x.real, y.real)
     if torch.is_complex(x) or torch.is_complex(y):
-        result += torch.vdot(x.imag, y.imag)
-    return result
+        imag_part = torch.einsum("...i,...i->...", x.imag, y.imag)
+        return real_part + imag_part
+    return real_part
 
 
 def _vdot_real_tree(x, y):
@@ -256,69 +257,51 @@ def _mul(scalar, tree):
 
 _add = partial(tree_map, operator.add)
 _sub = partial(tree_map, operator.sub)
-
-
-@Partial
-def _identity(x):
-    return x
+_identity = partial(lambda x: x)
 
 
 def cg(
-    A,
-    b,
-    x0=None,
+    A: Callable,
+    b: TensorTree,
+    x0: TensorTree = None,
     *,
-    maxiter=None,
-    damping=1e-5,
-    tol=torch.Tensor([1e-5]),
-    atol=torch.Tensor([0]),
-    M=_identity,
+    maxiter: int = None,
+    damping: float = 0,
+    tol: Tensor = torch.Tensor([1e-5]),
+    atol: Tensor = torch.Tensor([0]),
+    M: Callable = _identity,
 ):
     """Use Conjugate Gradient iteration to solve ``Ax = b``.
-
-    The numerics of JAX's ``cg`` should exact match SciPy's ``cg`` (up to
-    numerical precision), but note that the interface is slightly different: you
-    need to supply the linear operator ``A`` as a function instead of a sparse
+    ``A`` is suplied as a function instead of a sparse
     matrix or ``LinearOperator``.
 
     Derivatives of ``cg`` are implemented via implicit differentiation with
     another ``cg`` solve, rather than by differentiating *through* the solver.
     They will be accurate only if both solves converge.
+    Adapted from
 
     Args:
 
-    A:
-        2D array or function that calculates the linear map (matrix-vector
-        product) ``Ax`` when called like ``A(x)`` or ``A @ x``. ``A`` must represent
-        a hermitian, positive definite matrix, and must return array(s) with the
-        same structure and shape as its argument.
-    b :
-        Right hand side of the linear system representing a single vector. Can be
-        stored as an array or Python container of array(s) with any shape.
+        A:  Callable that calculates the linear map (matrix-vector
+            product) ``Ax`` when called like ``A(x)``. ``A`` must represent
+            a hermitian, positive definite matrix, and must return array(s) with the
+            same structure and shape as its argument.
+        b : Right hand side of the linear system representing a single vector.
+        x0 : Starting guess for the solution. Must have the same structure as ``b``.
+        tol, atol : Tolerances for convergence, ``norm(residual) <= max(tol*norm(b), atol)``.
+            The behaviour will differ from SciPy unless you explicitly pass
+            ``atol`` to SciPy's ``cg``.
+        maxiter : Maximum number of iterations.  Iteration will stop after maxiter
+            steps even if the specified tolerance has not been achieved.
+        M : Preconditioner for A.
+            See https://en.wikipedia.org/wiki/Conjugate_gradient_method#The_preconditioned_conjugate_gradient_method
 
     Returns
-    x : array or tree of arrays
-        The converged solution. Has the same structure as ``b``.
-    info : None
-        Placeholder for convergence information. In the future, JAX will report
-        the number of iterations when convergence is not achieved, like SciPy.
+        x : array or tree of arrays
+            The converged solution. Has the same structure as ``b``.
+        info : Placeholder for convergence information. In the future, JAX will report
+            the number of iterations when convergence is not achieved, like SciPy.
 
-    Other Parameters
-    ----------------
-    x0 : array or tree of arrays
-        Starting guess for the solution. Must have the same structure as ``b``.
-    tol, atol : float, optional
-        Tolerances for convergence, ``norm(residual) <= max(tol*norm(b), atol)``.
-        We do not implement SciPy's "legacy" behavior, so JAX's tolerance will
-        differ from SciPy unless you explicitly pass ``atol`` to SciPy's ``cg``.
-    maxiter : integer
-        Maximum number of iterations.  Iteration will stop after maxiter
-        steps even if the specified tolerance has not been achieved.
-    M : ndarray, function, or matmul-compatible object
-        Preconditioner for A.  The preconditioner should approximate the
-        inverse of A.  Effective preconditioning dramatically improves the
-        rate of convergence, which implies that fewer iterations are needed
-        to reach a given error tolerance.
     """
     if x0 is None:
         x0 = tree_map(torch.zeros_like, b)
@@ -331,7 +314,8 @@ def cg(
     bs = _vdot_real_tree(b, b)
     atol2 = torch.maximum(torch.square(tol) * bs, torch.square(atol))
 
-    # https://en.wikipedia.org/wiki/Conjugate_gradient_method#The_preconditioned_conjugate_gradient_method
+    def A_damped(p):
+        return _add(A(p), _mul(damping, p))
 
     def cond_fun(value):
         _, r, gamma, _, k = value
@@ -340,7 +324,7 @@ def cg(
 
     def body_fun(value):
         x, r, gamma, p, k = value
-        Ap = _add(A(p), _mul(damping, p))
+        Ap = A_damped(p)
         alpha = gamma / _vdot_real_tree(p, Ap)  # .astype(dtype)
         x_ = _add(x, _mul(alpha, p))
         r_ = _sub(r, _mul(alpha, Ap))
@@ -350,7 +334,7 @@ def cg(
         p_ = _add(z_, _mul(beta_, p))
         return x_, r_, gamma_, p_, k + 1
 
-    r0 = _sub(b, A(x0))
+    r0 = _sub(b, A_damped(x0))
     p0 = z0 = r0
     gamma0 = _vdot_real_tree(r0, z0)
     initial_value = (x0, r0, gamma0, p0, 0)

--- a/posteriors/utils.py
+++ b/posteriors/utils.py
@@ -292,14 +292,14 @@ def cg(
             same structure and shape as its argument.
         b:  Right hand side of the linear system representing a single vector.
         x0: Starting guess for the solution. Must have the same structure as ``b``.
-        maxiter : Maximum number of iterations.  Iteration will stop after maxiter
+        maxiter: Maximum number of iterations.  Iteration will stop after maxiter
             steps even if the specified tolerance has not been achieved.
-        damping : damping term for the mvp function. Acts as regularization.
+        damping: damping term for the mvp function. Acts as regularization.
         tol: Tolerance for convergence.
         atol: Tolerance for convergence. ``norm(residual) <= max(tol*norm(b), atol)``.
             The behaviour will differ from SciPy unless you explicitly pass
             ``atol`` to SciPy's ``cg``.
-        M : Preconditioner for A.
+        M: Preconditioner for A.
             See [the preconditioned CG method.](https://en.wikipedia.org/wiki/Conjugate_gradient_method#The_preconditioned_conjugate_gradient_method)
 
     Returns:

--- a/posteriors/utils.py
+++ b/posteriors/utils.py
@@ -272,8 +272,8 @@ def _identity(x):
 def cg(
     A: Callable,
     b: TensorTree,
-    *,
     x0: TensorTree = None,
+    *,
     maxiter: int = None,
     damping: float = 0.0,
     tol: float = 1e-5,
@@ -300,7 +300,7 @@ def cg(
             The behaviour will differ from SciPy unless you explicitly pass
             ``atol`` to SciPy's ``cg``.
         M : Preconditioner for A.
-            See https://en.wikipedia.org/wiki/Conjugate_gradient_method#The_preconditioned_conjugate_gradient_method
+            See [the preconditioned CG method.](https://en.wikipedia.org/wiki/Conjugate_gradient_method#The_preconditioned_conjugate_gradient_method)
 
     Returns:
         x : The converged solution. Has the same structure as ``b``.

--- a/posteriors/utils.py
+++ b/posteriors/utils.py
@@ -272,6 +272,7 @@ def _identity(x):
 def cg(
     A: Callable,
     b: TensorTree,
+    *,
     x0: TensorTree = None,
     maxiter: int = None,
     damping: float = 0.0,
@@ -284,7 +285,7 @@ def cg(
 
     Adapted from [`jax.scipy.sparse.linalg.cg`](https://jax.readthedocs.io/en/latest/_autosummary/jax.scipy.sparse.linalg.cg.html).
 
-    Args: 
+    Args:
         A:  Callable that calculates the linear map (matrix-vector
             product) ``Ax`` when called like ``A(x)``. ``A`` must represent
             a hermitian, positive definite matrix, and must return array(s) with the
@@ -303,7 +304,7 @@ def cg(
 
     Returns:
         x : The converged solution. Has the same structure as ``b``.
-        info : Placeholder for convergence information. 
+        info : Placeholder for convergence information.
     """
     if x0 is None:
         x0 = tree_map(torch.zeros_like, b)

--- a/posteriors/utils.py
+++ b/posteriors/utils.py
@@ -331,11 +331,11 @@ def cg(
     def body_fun(value):
         x, r, gamma, p, k = value
         Ap = A_damped(p)
-        alpha = gamma / _vdot_real_tree(p, Ap)  
+        alpha = gamma / _vdot_real_tree(p, Ap)
         x_ = _add(x, _mul(alpha, p))
         r_ = _sub(r, _mul(alpha, Ap))
         z_ = M(r_)
-        gamma_ = _vdot_real_tree(r_, z_) 
+        gamma_ = _vdot_real_tree(r_, z_)
         beta_ = gamma_ / gamma
         p_ = _add(z_, _mul(beta_, p))
         return x_, r_, gamma_, p_, k + 1

--- a/posteriors/utils.py
+++ b/posteriors/utils.py
@@ -272,19 +272,19 @@ def cg(
     x0: TensorTree = None,
     *,
     maxiter: int = None,
-    damping: float = 0,
+    damping: float = 0.0,
     tol: Tensor = torch.Tensor([1e-5]),
     atol: Tensor = torch.Tensor([0]),
     M: Callable = _identity,
 ) -> Tuple[TensorTree, Any]:
     """Use Conjugate Gradient iteration to solve ``Ax = b``.
-    ``A`` is suplied as a function instead of a sparse
+    ``A`` is supplied as a function instead of a sparse
     matrix or ``LinearOperator``.
 
     Derivatives of ``cg`` are implemented via implicit differentiation with
     another ``cg`` solve, rather than by differentiating *through* the solver.
     They will be accurate only if both solves converge.
-    Adapted from https://jax.readthedocs.io/en/latest/_autosummary/jax.scipy.sparse.linalg.cg.html.
+    Adapted from https://jax.readthedocs.io/en/latest/_autosummary/jax.scipy.sparse.linalg.cg.html
 
     Args:
 
@@ -313,8 +313,7 @@ def cg(
         x0 = tree_map(torch.zeros_like, b)
 
     if maxiter is None:
-        size = sum(bi.numel() for bi in tree_leaves(b))
-        maxiter = 10 * size  # copied from scipy
+        maxiter = 10 * tree_size(b)  # copied from scipy
 
     # tolerance handling uses the "non-legacy" behavior of scipy.sparse.linalg.cg
     bs = _vdot_real_tree(b, b)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -274,12 +274,11 @@ def test_cg():
 
     jac = torch.func.jacrev(func)(x)
     fisher = jac.T @ jac
-    damping = 1
+    damping = 100
 
     sol = torch.linalg.solve(fisher + damping * torch.eye(fisher.shape[0]), v)
-    sol_cg, _ = cg(partial_fvp, v, x0=None, damping=damping, tol=1e-10)
-
-    assert torch.allclose(sol, sol_cg, rtol=1e-1)
+    sol_cg, _ = cg(partial_fvp, v, x0=None, damping=damping, maxiter=10000, tol=1e-10)
+    assert torch.allclose(sol, sol_cg, rtol=1e-3)
 
     # simple complex number example
     A = torch.tensor([[0, -1j], [1j, 0]])

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -277,7 +277,20 @@ def test_cg():
     damping = 1
 
     sol = torch.linalg.solve(fisher + damping * torch.eye(fisher.shape[0]), v)
-    sol_cg, _ = cg(partial_fvp, v, x0=None, damping=damping, tol=torch.Tensor([1e-10]))
+    sol_cg, _ = cg(partial_fvp, v, x0=None, damping=damping, tol=1e-10)
+
+    assert torch.allclose(sol, sol_cg, rtol=1e-1)
+
+    # simple complex number example
+    A = torch.tensor([[0, -1j], [1j, 0]])
+
+    def mvp(x):
+        return A @ x
+
+    b = torch.randn(2, dtype=torch.cfloat)
+
+    sol = torch.linalg.solve(A, b)
+    sol_cg, _ = cg(mvp, b, x0=None, tol=1e-10)
 
     assert torch.allclose(sol, sol_cg, rtol=1e-1)
 
@@ -298,9 +311,7 @@ def test_cg():
 
     v, _ = tree_ravel(params)
     sol = torch.linalg.solve(fisher + damping * torch.eye(fisher.shape[0]), v)
-    sol_cg, _ = cg(
-        partial_fvp, params, x0=None, damping=damping, tol=torch.Tensor([1e-10])
-    )
+    sol_cg, _ = cg(partial_fvp, params, x0=None, damping=damping, tol=1e-10)
 
     assert torch.allclose(sol, tree_ravel(sol_cg)[0], rtol=1e-3)
 


### PR DESCRIPTION
Adapted from https://jax.readthedocs.io/en/latest/_autosummary/jax.scipy.sparse.linalg.cg.html

