### PR TITLE
Extend CatchAuxError to non TensorTree aux

### DIFF
--- a/posteriors/utils.py
+++ b/posteriors/utils.py
@@ -11,7 +11,8 @@ from optree.integration.torch import tree_ravel
 from posteriors.types import TensorTree, ForwardFn, Tensor
 
 
-AUX_ERROR_MSG = "should be a tuple: (output, aux) if has_aux is True"
+NO_AUX_ERROR_MSG = "should be a tuple: (output, aux) if has_aux is True"
+NON_TENSOR_AUX_ERROR_MSG = "Expected tensors, got unsupported type"
 
 
 class CatchAuxError(contextlib.AbstractContextManager):
@@ -19,11 +20,18 @@ class CatchAuxError(contextlib.AbstractContextManager):
 
     def __exit__(self, exc_type, exc_value, traceback):
         if exc_type is not None:
-            if AUX_ERROR_MSG in str(exc_value):
+            if NO_AUX_ERROR_MSG in str(exc_value):
                 raise RuntimeError(
                     "Auxiliary output not found. Perhaps you have forgotten to return "
                     "the aux output?\n"
                     "\tIf you don't have any auxiliary info, simply amend to e.g. "
+                    "log_posterior(params, batch) -> Tuple[float, torch.tensor([])].\n"
+                    "\tMore info at https://normal-computing.github.io/posteriors/log_posteriors"
+                )
+            elif NON_TENSOR_AUX_ERROR_MSG in str(exc_value):
+                raise RuntimeError(
+                    "Auxiliary output should be a TensorTree. If you don't have any "
+                    "auxiliary info, simply amend to e.g. "
                     "log_posterior(params, batch) -> Tuple[float, torch.tensor([])].\n"
                     "\tMore info at https://normal-computing.github.io/posteriors/log_posteriors"
                 )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -30,7 +30,7 @@ from posteriors import (
     per_samplify,
     is_scalar,
 )
-from posteriors.utils import AUX_ERROR_MSG
+from posteriors.utils import NO_AUX_ERROR_MSG, NON_TENSOR_AUX_ERROR_MSG
 from tests.scenarios import TestModel, TestLanguageModel
 
 
@@ -38,27 +38,51 @@ def test_CatchAuxError():
     def func(x):
         return x**2
 
-    def func_aux(x):
+    def func_aux_none(x):
         return x**2, None
 
-    # Check AUX_ERROR_MSG is correct
+    def func_aux(x):
+        return x**2, torch.tensor([])
+
+    # Check NO_AUX_ERROR_MSG is correct
     try:
         torch.func.grad(func, has_aux=True)(torch.tensor(1.0))
     except Exception as e:
-        assert AUX_ERROR_MSG in str(e)
+        assert NO_AUX_ERROR_MSG in str(e)
 
+    # Check NON_TENSOR_AUX_ERROR_MSG is correct
+    try:
+        torch.func.grad(func_aux_none, has_aux=True)(torch.tensor(1.0))
+    except Exception as e:
+        assert NON_TENSOR_AUX_ERROR_MSG in str(e)
+
+    # Check CatchAuxError works for NO_AUX_ERROR_MSG
     with pytest.raises(RuntimeError) as e:
         with CatchAuxError():
             torch.func.grad(func, has_aux=True)(torch.tensor(1.0))
 
-        assert "Auxiliary output not found" in str(e)
+    assert "Auxiliary output not found" in str(e)
 
     with pytest.raises(RuntimeError) as e:
         with torch.no_grad(), CatchAuxError():
             torch.func.grad(func, has_aux=True)(torch.tensor(1.0))
 
-        assert "Auxiliary output not found" in str(e)
+    assert "Auxiliary output not found" in str(e)
 
+    # Check CatchAuxError works for NON_TENSOR_AUX_ERROR_MSG
+    with pytest.raises(RuntimeError) as e:
+        with CatchAuxError():
+            torch.func.grad(func_aux_none, has_aux=True)(torch.tensor(1.0))
+
+    assert "Auxiliary output should be a TensorTree" in str(e)
+
+    with pytest.raises(RuntimeError) as e:
+        with torch.no_grad(), CatchAuxError():
+            torch.func.grad(func_aux_none, has_aux=True)(torch.tensor(1.0))
+
+    assert "Auxiliary output should be a TensorTree" in str(e)
+
+    # Check CatchAuxError works for correct func_aux
     with CatchAuxError():
         torch.func.grad(func_aux, has_aux=True)(torch.tensor(1.0))
 


### PR DESCRIPTION
- Extend CatchAuxError scope to also throw an error when the auxiliary output is not a TensorTree
- Fix tests