### PR TITLE
Add default argument for check function in tree_insert and tree_extract

### DIFF
--- a/examples/yelp/load.py
+++ b/examples/yelp/load.py
@@ -105,16 +105,16 @@ def load_model(
     if params_dir is not None:
         state = pickle.load(open(params_dir, "rb"))
         params = tree_insert(
-            lambda x: x.numel() == 0,
             state.params,
             dict(model.named_parameters()),
+            lambda x: x.numel() == 0,
         )
         if last_layer_params_dir is not None:
             last_layer_state = pickle.load(open(last_layer_params_dir, "rb"))
             params = tree_insert(
-                lambda x: x.numel() == 0,
                 last_layer_state.params,
                 params,
+                lambda x: x.numel() == 0,
             )
 
         model.load_state_dict(params)

--- a/posteriors/tree_utils.py
+++ b/posteriors/tree_utils.py
@@ -23,13 +23,16 @@ def tree_size(tree: TensorTree) -> int:
     return tree_reduce(torch.add, tree_map(lambda x: ensure_tensor(x).numel(), tree))
 
 
-def tree_extract(f: Callable[[torch.tensor], bool], tree: TensorTree) -> TensorTree:
+def tree_extract(
+    tree: TensorTree,
+    f: Callable[[torch.tensor], bool],
+) -> TensorTree:
     """Extracts values from a PyTree where f returns True.
     False values are replaced with empty tensors.
 
     Args:
-        f: A function that takes a PyTree element and returns True or False.
         tree: A PyTree.
+        f: A function that takes a PyTree element and returns True or False.
 
     Returns:
         A PyTree with the same structure as tree where f returns True.
@@ -38,15 +41,18 @@ def tree_extract(f: Callable[[torch.tensor], bool], tree: TensorTree) -> TensorT
 
 
 def tree_insert(
-    f: Callable[[torch.tensor], bool], full_tree: TensorTree, sub_tree: TensorTree
+    full_tree: TensorTree,
+    sub_tree: TensorTree,
+    f: Callable[[torch.tensor], bool] = lambda _: True,
 ) -> TensorTree:
     """Inserts sub_tree into full_tree where full_tree tensors evaluate f to True.
     Both PyTrees must have the same structure.
 
     Args:
-        f: A function that takes a PyTree element and returns True or False.
         full_tree: A PyTree to insert sub_tree into.
         sub_tree: A PyTree to insert into full_tree.
+        f: A function that takes a PyTree element and returns True or False.
+            Defaults to lambda _: True. I.e. insert on all leaves.
 
     Returns:
         A PyTree with sub_tree inserted into full_tree.
@@ -59,15 +65,18 @@ def tree_insert(
 
 
 def tree_insert_(
-    f: Callable[[torch.tensor], bool], full_tree: TensorTree, sub_tree: TensorTree
+    full_tree: TensorTree,
+    sub_tree: TensorTree,
+    f: Callable[[torch.tensor], bool] = lambda _: True,
 ) -> TensorTree:
     """Inserts sub_tree into full_tree in-place where full_tree tensors evaluate
     f to True. Both PyTrees must have the same structure.
 
     Args:
-        f: A function that takes a PyTree element and returns True or False.
         full_tree: A PyTree to insert sub_tree into.
         sub_tree: A PyTree to insert into full_tree.
+        f: A function that takes a PyTree element and returns True or False.
+            Defaults to lambda _: True. I.e. insert on all leaves.
 
     Returns:
         A pointer to full_tree with sub_tree inserted.
@@ -89,7 +98,7 @@ def extract_requires_grad(tree: TensorTree) -> TensorTree:
     Returns:
         A PyTree of tensors that require gradients.
     """
-    return tree_extract(lambda x: x.requires_grad, tree)
+    return tree_extract(tree, lambda x: x.requires_grad)
 
 
 def insert_requires_grad(full_tree: TensorTree, sub_tree: TensorTree) -> TensorTree:
@@ -103,7 +112,7 @@ def insert_requires_grad(full_tree: TensorTree, sub_tree: TensorTree) -> TensorT
     Returns:
         A PyTree with sub_tree inserted into full_tree.
     """
-    return tree_insert(lambda x: x.requires_grad, full_tree, sub_tree)
+    return tree_insert(full_tree, sub_tree, lambda x: x.requires_grad)
 
 
 def insert_requires_grad_(full_tree: TensorTree, sub_tree: TensorTree) -> TensorTree:
@@ -117,7 +126,7 @@ def insert_requires_grad_(full_tree: TensorTree, sub_tree: TensorTree) -> Tensor
     Returns:
         A pointer to full_tree with sub_tree inserted.
     """
-    return tree_insert_(lambda x: x.requires_grad, full_tree, sub_tree)
+    return tree_insert_(full_tree, sub_tree, lambda x: x.requires_grad)
 
 
 def extract_requires_grad_and_func(

--- a/tests/test_tree_utils.py
+++ b/tests/test_tree_utils.py
@@ -39,7 +39,7 @@ def test_tree_extract():
     def check_func(x):
         return x[0] < 2.0
 
-    result = tree_extract(check_func, params)
+    result = tree_extract(params, check_func)
 
     expected = {
         "a": torch.tensor([1.0, 2.0]),
@@ -69,7 +69,7 @@ def test_tree_insert():
     def check_func(x):
         return x[0] < 2.0
 
-    params2 = tree_insert(check_func, params, sub_params)
+    params2 = tree_insert(params, sub_params, check_func)
 
     expected = {
         "a": torch.tensor([5.0, 6.0]),
@@ -78,6 +78,13 @@ def test_tree_insert():
 
     for key in expected:
         assert torch.equal(params2[key], expected[key])
+        assert torch.equal(params[key], params_static[key])
+
+    # Check default check_func
+    params3 = tree_insert(params, sub_params)
+
+    for key in expected:
+        assert torch.equal(params3[key], sub_params[key])
         assert torch.equal(params[key], params_static[key])
 
 
@@ -95,7 +102,7 @@ def test_tree_insert_():
     def check_func(x):
         return x[0] < 2.0
 
-    params2 = tree_insert_(check_func, params, sub_params)
+    params2 = tree_insert_(params, sub_params, check_func)
 
     expected = {
         "a": torch.tensor([5.0, 6.0]),
@@ -105,6 +112,13 @@ def test_tree_insert_():
     for key in expected:
         assert torch.equal(params2[key], expected[key])
         assert torch.equal(params[key], params2[key])
+
+    # Check default check_func
+    params3 = tree_insert_(params, sub_params)
+
+    for key in expected:
+        assert torch.equal(params3[key], sub_params[key])
+        assert torch.equal(params[key], params3[key])
 
 
 def test_extract_requires_grad():


### PR DESCRIPTION
Adding the default argument meant a reordering of the signature.

This is in preparation for a refactor regarding #83 by changing `TransformState` to a `NamedTuple`.

This default `tree_insert` behaviour will be useful for updating tensor tree elements of a `NamedTuple` in-place, e.g. `tree_insert_(state.aux, aux)`