### PR TITLE
Change TransformState to NamedTuple

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -64,7 +64,7 @@ Here:
 - `build` is a function that loads `config_args` into the `init` and `update` functions
  and stores them within the `transform` instance. The `init` and `update` 
  functions then conform to a preset signature allowing for easy switching between algorithms.
-- `state` is a [`dataclass`](https://docs.python.org/3/library/dataclasses.html)
+- `state` is a [`NamedTuple`](https://docs.python.org/3/library/typing.html#typing.NamedTuple)
     encoding the state of the algorithm, including `params` and `aux` attributes.
 - `init` constructs the iteration-varying `state` based on the model parameters `params`.
 - `update` updates the `state` based on a new `batch` of data.

--- a/docs/gotchas.md
+++ b/docs/gotchas.md
@@ -70,6 +70,29 @@ state2 = transform.update(state, batch, inplace=True)
 # state is updated and state2 is a pointer to state
 ```
 
+When adding a new algorithm, in-place support can be achieved by modifying `TensorTree`s
+via the [`flexi_tree_map`](https://normal-computing.github.io/posteriors/api/tree_utils/#posteriors.tree_utils.flexi_tree_map) function:
+
+```python
+from posteriors.tree_utils import flexi_tree_map
+
+new_state = flexi_tree_map(lambda x: x + 1, state, inplace=True)
+```
+
+As `posteriors` transform states are immutable `NamedTuple`s, in-place modification of
+`TensorTree` leaves can be achieved by modifying the data of the tensor directly with [`tree_insert_`](https://normal-computing.github.io/posteriors/api/tree_utils/#posteriors.tree_utils.tree_insert_):
+
+```python
+from posteriors.tree_utils import tree_insert_
+
+tree_insert_(state.log_posterior, log_post.detach())
+```
+
+However, the `aux` component of the `TransformState` is not guaranteed to be a `TensorTree`,
+and so in-place modification of `aux` is not supported. Using `state._replace(aux=aux)`
+will return a state with all `TensorTree` pointing to the same memory as input `state`,
+but with a new `aux` component (`aux` is not modified in the input `state` object).
+
 
 ## `torch.tensor` with autograd
 

--- a/docs/tutorials/lightning_autoencoder.md
+++ b/docs/tutorials/lightning_autoencoder.md
@@ -16,7 +16,6 @@ from torchvision.datasets import MNIST
 from torchvision.transforms import ToTensor
 import lightning as L
 import torchopt
-from dataclasses import asdict
 
 import posteriors
 
@@ -100,7 +99,7 @@ class LitAutoEncoderUQ(L.LightningModule):
         # it is independent of forward
         self.state = self.transform.update(self.state, batch, inplace=True)
         # Logging to TensorBoard (if installed) by default
-        for k, v in asdict(self.state).items():
+        for k, v in self.state._asdict().items():
             if isinstance(v, float) or (isinstance(v, torch.Tensor) and v.numel() == 1):
                 self.log(k, v)
 

--- a/examples/lightning_autoencoder.py
+++ b/examples/lightning_autoencoder.py
@@ -5,7 +5,6 @@ from torchvision.datasets import MNIST
 from torchvision.transforms import ToTensor
 import lightning as L
 import torchopt
-from dataclasses import asdict
 
 import posteriors
 
@@ -54,7 +53,7 @@ class LitAutoEncoderUQ(L.LightningModule):
         # it is independent of forward
         self.state = self.transform.update(self.state, batch, inplace=True)
         # Logging to TensorBoard (if installed) by default
-        for k, v in asdict(self.state).items():
+        for k, v in self.state._asdict().items():
             if isinstance(v, float) or (isinstance(v, torch.Tensor) and v.numel() == 1):
                 self.log(k, v)
 

--- a/posteriors/ekf/dense_fisher.py
+++ b/posteriors/ekf/dense_fisher.py
@@ -69,7 +69,7 @@ def build(
 class EKFDenseState(NamedTuple):
     """State encoding a Normal distribution over parameters.
 
-    Args:
+    Attributes:
         params: Mean of the Normal distribution.
         cov: Covariance matrix of the
             Normal distribution.

--- a/posteriors/ekf/diag_fisher.py
+++ b/posteriors/ekf/diag_fisher.py
@@ -70,7 +70,7 @@ def build(
 class EKFDiagState(NamedTuple):
     """State encoding a diagonal Normal distribution over parameters.
 
-    Args:
+    Attributes:
         params: Mean of the Normal distribution.
         sd_diag: Square-root diagonal of the covariance matrix of the
             Normal distribution.

--- a/posteriors/laplace/dense_fisher.py
+++ b/posteriors/laplace/dense_fisher.py
@@ -58,7 +58,7 @@ class DenseLaplaceState(NamedTuple):
     """State encoding a Normal distribution over parameters,
     with a dense precision matrix
 
-    Args:
+    Attributes:
         params: Mean of the Normal distribution.
         prec: Precision matrix of the Normal distribution.
         aux: Auxiliary information from the log_posterior call.

--- a/posteriors/laplace/dense_fisher.py
+++ b/posteriors/laplace/dense_fisher.py
@@ -1,11 +1,10 @@
-from typing import Any
-from dataclasses import dataclass
+from typing import Any, NamedTuple
 from functools import partial
 import torch
 from optree import tree_map
 from optree.integration.torch import tree_ravel
 
-from posteriors.types import TensorTree, Transform, LogProbFn, TransformState
+from posteriors.types import TensorTree, Transform, LogProbFn
 from posteriors.tree_utils import tree_size
 from posteriors.utils import (
     per_samplify,
@@ -55,8 +54,7 @@ def build(
     return Transform(init_fn, update_fn)
 
 
-@dataclass
-class DenseLaplaceState(TransformState):
+class DenseLaplaceState(NamedTuple):
     """State encoding a Normal distribution over parameters,
     with a dense precision matrix
 
@@ -130,9 +128,8 @@ def update(
         )(state.params)
 
     if inplace:
-        state.prec += fisher
-        state.aux = aux
-        return state
+        state.prec.data += fisher
+        return state._replace(aux=aux)
     else:
         return DenseLaplaceState(state.params, state.prec + fisher, aux)
 

--- a/posteriors/laplace/dense_ggn.py
+++ b/posteriors/laplace/dense_ggn.py
@@ -69,7 +69,7 @@ class DenseLaplaceState(NamedTuple):
     """State encoding a Normal distribution over parameters,
     with a dense precision matrix
 
-    Args:
+    Attributes:
         params: Mean of the Normal distribution.
         prec: Precision matrix of the Normal distribution.
         aux: Auxiliary information from the log_posterior call.

--- a/posteriors/laplace/dense_ggn.py
+++ b/posteriors/laplace/dense_ggn.py
@@ -1,8 +1,7 @@
 from functools import partial
-from typing import Any
+from typing import Any, NamedTuple
 import torch
 from optree import tree_map
-from dataclasses import dataclass
 from optree.integration.torch import tree_ravel
 
 from posteriors.types import (
@@ -10,7 +9,6 @@ from posteriors.types import (
     Transform,
     ForwardFn,
     OuterLogProbFn,
-    TransformState,
 )
 from posteriors.utils import (
     tree_size,
@@ -67,8 +65,7 @@ def build(
     return Transform(init_fn, update_fn)
 
 
-@dataclass
-class DenseLaplaceState(TransformState):
+class DenseLaplaceState(NamedTuple):
     """State encoding a Normal distribution over parameters,
     with a dense precision matrix
 
@@ -145,9 +142,8 @@ def update(
         )(state.params)
 
     if inplace:
-        state.prec += ggn_batch
-        state.aux = aux
-        return state
+        state.prec.data += ggn_batch
+        return state._replace(aux=aux)
     else:
         return DenseLaplaceState(state.params, state.prec + ggn_batch, aux)
 

--- a/posteriors/laplace/diag_fisher.py
+++ b/posteriors/laplace/diag_fisher.py
@@ -56,7 +56,7 @@ def build(
 class DiagLaplaceState(NamedTuple):
     """State encoding a diagonal Normal distribution over parameters.
 
-    Args:
+    Attributes:
         params: Mean of the Normal distribution.
         prec_diag: Diagonal of the precision matrix of the Normal distribution.
         aux: Auxiliary information from the log_posterior call.

--- a/posteriors/laplace/diag_fisher.py
+++ b/posteriors/laplace/diag_fisher.py
@@ -1,11 +1,10 @@
 from functools import partial
-from typing import Any
+from typing import Any, NamedTuple
 import torch
 from torch.func import jacrev
 from optree import tree_map
-from dataclasses import dataclass
 
-from posteriors.types import TensorTree, Transform, LogProbFn, TransformState
+from posteriors.types import TensorTree, Transform, LogProbFn
 from posteriors.tree_utils import flexi_tree_map
 from posteriors.utils import (
     diag_normal_sample,
@@ -54,8 +53,7 @@ def build(
     return Transform(init_fn, update_fn)
 
 
-@dataclass
-class DiagLaplaceState(TransformState):
+class DiagLaplaceState(NamedTuple):
     """State encoding a diagonal Normal distribution over parameters.
 
     Args:
@@ -134,8 +132,7 @@ def update(
     )
 
     if inplace:
-        state.aux = aux
-        return state
+        return state._replace(aux=aux)
     return DiagLaplaceState(state.params, prec_diag, aux)
 
 

--- a/posteriors/laplace/diag_ggn.py
+++ b/posteriors/laplace/diag_ggn.py
@@ -67,7 +67,7 @@ def build(
 class DiagLaplaceState(NamedTuple):
     """State encoding a diagonal Normal distribution over parameters.
 
-    Args:
+    Attributes:
         params: Mean of the Normal distribution.
         prec_diag: Diagonal of the precision matrix of the Normal distribution.
         aux: Auxiliary information from the log_posterior call.

--- a/posteriors/laplace/diag_ggn.py
+++ b/posteriors/laplace/diag_ggn.py
@@ -1,15 +1,13 @@
 from functools import partial
-from typing import Any
+from typing import Any, NamedTuple
 import torch
 from optree import tree_map
-from dataclasses import dataclass
 
 from posteriors.types import (
     TensorTree,
     Transform,
     ForwardFn,
     OuterLogProbFn,
-    TransformState,
 )
 from posteriors.tree_utils import flexi_tree_map
 from posteriors.utils import (
@@ -66,8 +64,7 @@ def build(
     return Transform(init_fn, update_fn)
 
 
-@dataclass
-class DiagLaplaceState(TransformState):
+class DiagLaplaceState(NamedTuple):
     """State encoding a diagonal Normal distribution over parameters.
 
     Args:
@@ -149,8 +146,7 @@ def update(
     )
 
     if inplace:
-        state.aux = aux
-        return state
+        return state._replace(aux=aux)
     return DiagLaplaceState(state.params, prec_diag, aux)
 
 

--- a/posteriors/optim.py
+++ b/posteriors/optim.py
@@ -39,7 +39,7 @@ def build(
 class OptimState(NamedTuple):
     """State of an optimizer from [torch.optim](https://pytorch.org/docs/stable/optim.html).
 
-    Args:
+    Attributes:
         params: Parameters to be optimized.
         optimizer: torch.optim optimizer instance.
         loss: Loss value.

--- a/posteriors/optim.py
+++ b/posteriors/optim.py
@@ -1,10 +1,10 @@
-from typing import Type, Any
+from typing import Type, Any, NamedTuple
 from functools import partial
 import torch
-from dataclasses import dataclass
 
-from posteriors.types import TensorTree, Transform, LogProbFn, TransformState
+from posteriors.types import TensorTree, Transform, LogProbFn
 from posteriors.utils import CatchAuxError
+from posteriors.tree_utils import tree_insert_
 
 
 def build(
@@ -36,8 +36,7 @@ def build(
     return Transform(init_fn, update_fn)
 
 
-@dataclass
-class OptimState(TransformState):
+class OptimState(NamedTuple):
     """State of an optimizer from [torch.optim](https://pytorch.org/docs/stable/optim.html).
 
     Args:
@@ -49,7 +48,7 @@ class OptimState(TransformState):
 
     params: TensorTree
     optimizer: torch.optim.Optimizer
-    loss: torch.tensor = None
+    loss: torch.tensor = torch.tensor([])
     aux: Any = None
 
 
@@ -104,6 +103,5 @@ def update(
         loss, aux = loss_fn(state.params, batch)
     loss.backward()
     state.optimizer.step()
-    state.loss = loss
-    state.aux = aux
-    return state
+    tree_insert_(state.loss, loss.detach())
+    return state._replace(aux=aux)

--- a/posteriors/sgmcmc/sghmc.py
+++ b/posteriors/sgmcmc/sghmc.py
@@ -67,7 +67,7 @@ def build(
 class SGHMCState(NamedTuple):
     """State encoding params and momenta for SGHMC.
 
-    Args:
+    Attributes:
         params: Parameters.
         momenta: Momenta for each parameter.
         log_posterior: Log posterior evaluation.

--- a/posteriors/sgmcmc/sgld.py
+++ b/posteriors/sgmcmc/sgld.py
@@ -1,11 +1,10 @@
-from typing import Any
+from typing import Any, NamedTuple
 from functools import partial
 import torch
 from torch.func import grad_and_value
-from dataclasses import dataclass
 
-from posteriors.types import TensorTree, Transform, LogProbFn, TransformState
-from posteriors.tree_utils import flexi_tree_map
+from posteriors.types import TensorTree, Transform, LogProbFn
+from posteriors.tree_utils import flexi_tree_map, tree_insert_
 from posteriors.utils import CatchAuxError
 
 
@@ -49,8 +48,7 @@ def build(
     return Transform(init, update_fn)
 
 
-@dataclass
-class SGLDState(TransformState):
+class SGLDState(NamedTuple):
     """State encoding params for SGLD.
 
     Args:
@@ -60,7 +58,7 @@ class SGLDState(TransformState):
     """
 
     params: TensorTree
-    log_posterior: torch.tensor = None
+    log_posterior: torch.tensor = torch.tensor([])
     aux: Any = None
 
 
@@ -124,7 +122,6 @@ def update(
     params = flexi_tree_map(transform_params, state.params, grads, inplace=inplace)
 
     if inplace:
-        state.log_posterior = log_post.detach()
-        state.aux = aux
-        return state
+        tree_insert_(state.log_posterior, log_post.detach())
+        return state._replace(aux=aux)
     return SGLDState(params, log_post.detach(), aux)

--- a/posteriors/sgmcmc/sgld.py
+++ b/posteriors/sgmcmc/sgld.py
@@ -51,7 +51,7 @@ def build(
 class SGLDState(NamedTuple):
     """State encoding params for SGLD.
 
-    Args:
+    Attributes:
         params: Parameters.
         log_posterior: Log posterior evaluation.
         aux: Auxiliary information from the log_posterior call.

--- a/posteriors/sgmcmc/sgnht.py
+++ b/posteriors/sgmcmc/sgnht.py
@@ -1,13 +1,12 @@
-from typing import Any
+from typing import Any, NamedTuple
 from functools import partial
 import torch
 from torch.func import grad_and_value
 from optree import tree_map
 from optree.integration.torch import tree_ravel
-from dataclasses import dataclass
 
-from posteriors.types import TensorTree, Transform, LogProbFn, TransformState
-from posteriors.tree_utils import flexi_tree_map
+from posteriors.types import TensorTree, Transform, LogProbFn
+from posteriors.tree_utils import flexi_tree_map, tree_insert_
 from posteriors.utils import is_scalar, CatchAuxError
 
 
@@ -68,8 +67,7 @@ def build(
     return Transform(init_fn, update_fn)
 
 
-@dataclass
-class SGNHTState(TransformState):
+class SGNHTState(NamedTuple):
     """State encoding params and momenta for SGNHT.
 
     Args:
@@ -81,13 +79,15 @@ class SGNHTState(TransformState):
 
     params: TensorTree
     momenta: TensorTree
-    xi: float
-    log_posterior: torch.tensor = None
+    xi: torch.tensor = torch.tensor([])
+    log_posterior: torch.tensor = torch.tensor([])
     aux: Any = None
 
 
 def init(
-    params: TensorTree, momenta: TensorTree | float | None = None, xi: float = 0.01
+    params: TensorTree,
+    momenta: TensorTree | float | None = None,
+    xi: float | torch.Tensor = 0.01,
 ) -> SGNHTState:
     """Initialise momenta for SGNHT.
 
@@ -111,7 +111,7 @@ def init(
             params,
         )
 
-    return SGNHTState(params, momenta, xi)
+    return SGNHTState(params, momenta, torch.tensor(xi))
 
 
 def update(
@@ -183,8 +183,7 @@ def update(
     momenta = flexi_tree_map(transform_momenta, state.momenta, grads, inplace=inplace)
 
     if inplace:
-        state.xi = xi_new
-        state.log_posterior = log_post.detach()
-        state.aux = aux
-        return state
+        tree_insert_(state.xi, xi_new)
+        tree_insert_(state.log_posterior, log_post.detach())
+        return state._replace(aux=aux)
     return SGNHTState(params, momenta, xi_new, log_post.detach(), aux)

--- a/posteriors/sgmcmc/sgnht.py
+++ b/posteriors/sgmcmc/sgnht.py
@@ -70,7 +70,7 @@ def build(
 class SGNHTState(NamedTuple):
     """State encoding params and momenta for SGNHT.
 
-    Args:
+    Attributes:
         params: Parameters.
         momenta: Momenta for each parameter.
         log_posterior: Log posterior evaluation.

--- a/posteriors/torchopt.py
+++ b/posteriors/torchopt.py
@@ -43,7 +43,7 @@ class TorchOptState(NamedTuple):
     Contains the parameters, the optimizer state for the TorchOpt optimizer,
     loss value, and auxiliary information.
 
-    Args:
+    Attributes:
         params: Parameters to be optimized.
         opt_state: TorchOpt optimizer state.
         loss: Loss value.

--- a/posteriors/types.py
+++ b/posteriors/types.py
@@ -17,8 +17,8 @@ class TransformState(NamedTuple):
     information for the posteriors iterative algorithm defined by the `init` and
     `update` functions.
 
-    Inherit the `NamedTuple` class (not `TransformState`) when defining a new
-    algorithm state, just make sure to include the `params` and `aux` fields.
+    Inherit the `NamedTuple` class when defining a new algorithm state, just make sure
+    to include the `params` and `aux` fields.
 
     ```
     class AlgorithmState(NamedTuple):

--- a/posteriors/types.py
+++ b/posteriors/types.py
@@ -26,6 +26,10 @@ class TransformState(NamedTuple):
         algorithm_info: Any
         aux: Any
     ```
+
+    Attributes:
+        params: PyTree containing the current value of parameters.
+        aux: Auxiliary information from the model call.
     """
 
     params: TensorTree
@@ -104,7 +108,7 @@ class Transform(NamedTuple):
     `build` function, the internal `init` and `update` functions in the
     algorithm module can and likely will have additional arguments.
 
-    Args:
+    Attributes:
         init: The init function.
         update: The update function.
 

--- a/posteriors/vi/diag.py
+++ b/posteriors/vi/diag.py
@@ -64,7 +64,7 @@ def build(
 class VIDiagState(NamedTuple):
     """State encoding a diagonal Normal variational distribution over parameters.
 
-    Args:
+    Attributes:
         params: Mean of the variational distribution.
         log_sd_diag: Log of the square-root diagonal of the covariance matrix of the
             variational distribution.

--- a/tests/ekf/test_diag_fisher.py
+++ b/tests/ekf/test_diag_fisher.py
@@ -37,15 +37,22 @@ def test_ekf_diag():
         assert not torch.allclose(state.params[key], init_mean[key])
 
     # Test inplace = True
+    init_mean = tree_map(lambda x: torch.zeros_like(x, requires_grad=True), target_mean)
+    init_mean_copy = tree_map(lambda x: x.clone(), init_mean)
     state = transform.init(init_mean)
     log_liks = []
     for _ in range(n_steps):
-        state = transform.update(state, batch, inplace=True)
+        new_state = transform.update(state, batch, inplace=True)
         log_liks.append(state.log_likelihood.item())
 
     for key in state.params:
         assert torch.allclose(state.params[key], target_mean[key], atol=1e-1)
-        assert torch.allclose(state.params[key], init_mean[key])
+        assert not torch.allclose(state.params[key], init_mean_copy[key])
+        assert not torch.allclose(init_mean[key], init_mean_copy[key])
+
+    assert (
+        state.aux != new_state.aux
+    )  # aux not changed in-place as not guaranteed to be a TensorTree
 
     # Test sample
     mean_copy = tree_map(lambda x: x.clone(), state.params)

--- a/tests/laplace/test_dense_fisher.py
+++ b/tests/laplace/test_dense_fisher.py
@@ -98,7 +98,7 @@ def test_dense_fisher_vmap():
 
     # Test sampling
     num_samples = 10000
-    laplace_state.prec = laplace_state.prec + 0.1 * torch.eye(
+    laplace_state.prec.data += 0.1 * torch.eye(
         num_params
     )  # regularize to ensure PSD and reduce variance
 

--- a/tests/laplace/test_dense_ggn.py
+++ b/tests/laplace/test_dense_ggn.py
@@ -79,7 +79,7 @@ def test_ggn_vmap():
 
     # Test sampling
     num_samples = 10000
-    laplace_state.prec = laplace_state.prec + 0.1 * torch.eye(
+    laplace_state.prec.data += 0.1 * torch.eye(
         flat_params.shape[0]
     )  # regularize to ensure PSD and reduce variance
 


### PR DESCRIPTION
This is quite a large PR unfortunately but fixes #83 and also cleans up the `TransformState` code by moving from mutable `dataclass` to immutable `NamedTuple` which is also better encapsulation practice for functional code.

One thing that's nice is that `NamedTuple` is already added to the pytree registry for optree and torch (fixing #83), so we don't need to do that manually as before.

There was an issue with the `aux` handling as modifying `aux` is not possible to do in-place as we don't know the structure of `aux` before `log_posterior` is called, also `aux` is not guaranteed to be a `TensorTree` and could contain strings etc. 

The proposed fix is to return a new state with all other attributes modified in-place (i.e. pointers to old state) but `aux` replaced.