### PR TITLE
speed up tests with pytest-xdist

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -36,4 +36,4 @@ jobs:
           pip install '.[test]'
       - name: Run the tests with pytest
         run: |
-          python -m pytest --cov=posteriors --cov-report term-missing
+          python -m pytest -n auto --cov=posteriors --cov-report term-missing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
 dependencies = ["torch>=2.0.0", "torchopt>=0.7.3", "optree>=0.10.0"]
 
 [project.optional-dependencies]
-test = ["pre-commit", "pytest-cov", "ruff"]
+test = ["pre-commit", "pytest-cov", "pytest-xdist", "ruff"]
 docs = ["mkdocs", "mkdocs-material", "mkdocstrings[python]"]
 
 [tool.setuptools]
@@ -32,6 +32,9 @@ packages = [
 [tool.ruff]
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["F401", "F821", "E402"]
+
+[tool.pytest.ini_options]
+addopts = "-n auto"
 
 [build-system]
 requires = ["setuptools>=64"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,8 +33,6 @@ packages = [
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["F401", "F821", "E402"]
 
-[tool.pytest.ini_options]
-addopts = "-n auto"
 
 [build-system]
 requires = ["setuptools>=64"]


### PR DESCRIPTION
Hi,

As I've been working on pull request #113, I've noticed that the tests are quite compute intensive and take a while to run.

I've added in [pytest-xdist ](https://pypi.org/project/pytest-xdist/) to see if it helps any, and on my 16 core machine it reduces test execution time from 1m46s to 1m, roughly 45% faster.
It's a "breaking change" in the sense that anyone who already has a local env installed will need to install pytest-xdist to run tests.

It's a small change that'll help the repo remain more manageable as it grows, so I thought to suggest it here :) 