### PR TITLE
Remove duplicate docs in update

### DIFF
--- a/posteriors/ekf/dense_fisher.py
+++ b/posteriors/ekf/dense_fisher.py
@@ -114,14 +114,8 @@ def update(
     inplace: bool = False,
 ) -> EKFDenseState:
     """Applies an extended Kalman Filter update to the Multivariate Normal distribution.
-    The approximate Bayesian update is based on the linearization
-    $$
-    \\log p(θ | y) ≈ \\log p(θ) +  ε g(μ)ᵀ(θ - μ) +  \\frac12 ε (θ - μ)^T F(μ) (θ - μ)
-    $$
-    where $μ$ is the mean of the prior distribution, $ε$ is the learning rate
-    (or equivalently the likelihood inverse temperature),
-    $g(μ)$ is the gradient of the log likelihood at μ and $F(μ)$ is the
-    empirical Fisher information matrix at $μ$ for data $y$.
+
+    See [build](dense_fisher.md#posteriors.ekf.dense_fisher.build) for details.
 
     Args:
         state: Current state.

--- a/posteriors/ekf/diag_fisher.py
+++ b/posteriors/ekf/diag_fisher.py
@@ -117,15 +117,8 @@ def update(
     inplace: bool = False,
 ) -> EKFDiagState:
     """Applies an extended Kalman Filter update to the diagonal Normal distribution.
-    The approximate Bayesian update is based on the linearization
-    $$
-    \\log p(θ | y) ≈ \\log p(θ) +  ε g(μ)ᵀ(θ - μ) +  \\frac12 ε (θ - μ)^T F_d(μ) (θ - μ)
-    $$
-    where $μ$ is the mean of the prior distribution, $ε$ is the learning rate
-    (or equivalently the likelihood inverse temperature),
-    $g(μ)$ is the gradient of the log likelihood at μ and $F_d(μ)$ is the diagonal
-    empirical Fisher information matrix at $μ$ for data $y$. Completing the square
-    regains a diagonal Normal distribution over the parameters.
+
+    See [build](diag_fisher.md#posteriors.ekf.diag_fisher.build) for details.
 
     Args:
         state: Current state.

--- a/posteriors/sgmcmc/sghmc.py
+++ b/posteriors/sgmcmc/sghmc.py
@@ -117,16 +117,9 @@ def update(
     inplace: bool = False,
 ) -> SGHMCState:
     """Updates parameters and momenta for SGHMC.
-    
-    Update rule from [Chen et al, 2014](https://arxiv.org/abs/1402.4102):
 
-    \\begin{align}
-    θ_{t+1} &= θ_t + ε σ^{-2} m_t \\\\
-    m_{t+1} &= m_t + ε \\nabla \\log p(θ_t, \\text{batch}) - ε σ^{-2} α m_t
-    + N(0, ε T (2 α - ε β T) \\mathbb{I})\\
-    \\end{align}
-    
-    for learning rate $\\epsilon$ and temperature $T$
+    Update rule from [Chen et al, 2014](https://arxiv.org/abs/1402.4102),
+    see [build](sghmc.md#posteriors.sgmcmc.sghmc.build) for details.
 
     Args:
         state: SGHMCState containing params and momenta.

--- a/posteriors/sgmcmc/sgld.py
+++ b/posteriors/sgmcmc/sgld.py
@@ -86,11 +86,8 @@ def update(
 ) -> SGLDState:
     """Updates parameters for SGLD.
 
-    Update rule from [Welling and Teh, 2011](https://www.stats.ox.ac.uk/~teh/research/compstats/WelTeh2011a.pdf):
-    $$
-    θ_{t+1} = θ_t + ε \\nabla \\log p(θ_t, \\text{batch}) + N(0, ε  (2 - ε β) T \\mathbb{I})
-    $$
-    for lr $\\epsilon$ and temperature $T$.
+    Update rule from [Welling and Teh, 2011](https://www.stats.ox.ac.uk/~teh/research/compstats/WelTeh2011a.pdf),
+    see [build](sgld.md#posteriors.sgmcmc.sgld.build) for details.
 
     Args:
         state: SGLDState containing params.

--- a/posteriors/sgmcmc/sgnht.py
+++ b/posteriors/sgmcmc/sgnht.py
@@ -126,17 +126,9 @@ def update(
     inplace: bool = False,
 ) -> SGNHTState:
     """Updates parameters, momenta and xi for SGNHT.
-    
-    Update rule from [Ding et al, 2014](https://proceedings.neurips.cc/paper/2014/file/21fe5b8ba755eeaece7a450849876228-Paper.pdf):
 
-    \\begin{align}
-    θ_{t+1} &= θ_t + ε σ^{-2} m_t \\\\
-    m_{t+1} &= m_t + ε \\nabla \\log p(θ_t, \\text{batch}) - ε σ^{-2} ξ_t m_t
-    + N(0, ε T (2 α - ε β T) \\mathbb{I})\\\\
-    ξ_{t+1} &= ξ_t + ε (σ^{-2} d^{-1} m_t^T m_t - T)
-    \\end{align}
-    
-    for learning rate $\\epsilon$ and temperature $T$
+    Update rule from [Ding et al, 2014](https://proceedings.neurips.cc/paper/2014/file/21fe5b8ba755eeaece7a450849876228-Paper.pdf),
+    see [build](sgnht.md#posteriors.sgmcmc.sgnht.build) for details.
 
     Args:
         state: SGNHTState containing params, momenta and xi.


### PR DESCRIPTION
Removes the double doc comments appearing in `build` and `update` in favour of the `update` docstring pointing to `build` for details.