### PR TITLE
Replace `NamedTuple` with `tensorclass`

### DIFF
--- a/posteriors/ekf/dense_fisher.py
+++ b/posteriors/ekf/dense_fisher.py
@@ -1,11 +1,11 @@
-from typing import Any, NamedTuple
+from typing import Any
 from functools import partial
 import torch
 from torch.func import grad_and_value
 from optree.integration.torch import tree_ravel
+from tensordict import tensorclass
 
 from posteriors.tree_utils import tree_size, tree_insert_
-
 from posteriors.types import TensorTree, Transform, LogProbFn
 from posteriors.utils import (
     per_samplify,
@@ -66,7 +66,8 @@ def build(
     return Transform(init_fn, update_fn)
 
 
-class EKFDenseState(NamedTuple):
+@tensorclass(frozen=True)
+class EKFDenseState:
     """State encoding a Normal distribution over parameters.
 
     Attributes:
@@ -165,7 +166,7 @@ def update(
         tree_insert_(state.params, update_mean)
         tree_insert_(state.cov, update_cov)
         tree_insert_(state.log_likelihood, log_liks.mean().detach())
-        return state._replace(aux=aux)
+        return state.replace(aux=aux)
 
     return EKFDenseState(update_mean, update_cov, log_liks.mean().detach(), aux)
 

--- a/posteriors/ekf/diag_fisher.py
+++ b/posteriors/ekf/diag_fisher.py
@@ -1,8 +1,9 @@
-from typing import Any, NamedTuple
+from typing import Any
 from functools import partial
 import torch
 from torch.func import jacrev
 from optree import tree_map
+from tensordict import tensorclass
 
 from posteriors.types import TensorTree, Transform, LogProbFn
 from posteriors.tree_utils import flexi_tree_map, tree_insert_
@@ -67,7 +68,8 @@ def build(
     return Transform(init_fn, update_fn)
 
 
-class EKFDiagState(NamedTuple):
+@tensorclass(frozen=True)
+class EKFDiagState:
     """State encoding a diagonal Normal distribution over parameters.
 
     Attributes:
@@ -168,7 +170,7 @@ def update(
 
     if inplace:
         tree_insert_(state.log_likelihood, log_liks.mean().detach())
-        return state._replace(aux=aux)
+        return state.replace(aux=aux)
 
     return EKFDiagState(update_mean, update_sd_diag, log_liks.mean().detach(), aux)
 

--- a/posteriors/laplace/dense_fisher.py
+++ b/posteriors/laplace/dense_fisher.py
@@ -1,9 +1,9 @@
-from typing import Any, NamedTuple
+from typing import Any
 from functools import partial
 import torch
 from optree import tree_map
 from optree.integration.torch import tree_ravel
-
+from tensordict import tensorclass
 from posteriors.types import TensorTree, Transform, LogProbFn
 from posteriors.tree_utils import tree_size
 from posteriors.utils import (
@@ -54,7 +54,8 @@ def build(
     return Transform(init_fn, update_fn)
 
 
-class DenseLaplaceState(NamedTuple):
+@tensorclass(frozen=True)
+class DenseLaplaceState:
     """State encoding a Normal distribution over parameters,
     with a dense precision matrix
 
@@ -129,7 +130,7 @@ def update(
 
     if inplace:
         state.prec.data += fisher
-        return state._replace(aux=aux)
+        return state.replace(aux=aux)
     else:
         return DenseLaplaceState(state.params, state.prec + fisher, aux)
 

--- a/posteriors/laplace/dense_ggn.py
+++ b/posteriors/laplace/dense_ggn.py
@@ -1,8 +1,9 @@
 from functools import partial
-from typing import Any, NamedTuple
+from typing import Any
 import torch
 from optree import tree_map
 from optree.integration.torch import tree_ravel
+from tensordict import tensorclass
 
 from posteriors.types import (
     TensorTree,
@@ -65,7 +66,8 @@ def build(
     return Transform(init_fn, update_fn)
 
 
-class DenseLaplaceState(NamedTuple):
+@tensorclass(frozen=True)
+class DenseLaplaceState:
     """State encoding a Normal distribution over parameters,
     with a dense precision matrix
 
@@ -143,7 +145,7 @@ def update(
 
     if inplace:
         state.prec.data += ggn_batch
-        return state._replace(aux=aux)
+        return state.replace(aux=aux)
     else:
         return DenseLaplaceState(state.params, state.prec + ggn_batch, aux)
 

--- a/posteriors/laplace/dense_hessian.py
+++ b/posteriors/laplace/dense_hessian.py
@@ -1,8 +1,9 @@
-from typing import Any, NamedTuple
+from typing import Any
 from functools import partial
 import torch
 from optree import tree_map
 from optree.integration.torch import tree_ravel
+from tensordict import tensorclass
 
 from posteriors.types import TensorTree, Transform, LogProbFn
 from posteriors.tree_utils import tree_size
@@ -51,7 +52,8 @@ def build(
     return Transform(init_fn, update_fn)
 
 
-class DenseLaplaceState(NamedTuple):
+@tensorclass(frozen=True)
+class DenseLaplaceState:
     """State encoding a Normal distribution over parameters,
     with a dense precision matrix
 
@@ -132,7 +134,7 @@ def update(
 
     if inplace:
         state.prec.data += hess
-        return state._replace(aux=aux)
+        return state.replace(aux=aux)
     else:
         return DenseLaplaceState(state.params, state.prec + hess, aux)
 

--- a/posteriors/laplace/diag_fisher.py
+++ b/posteriors/laplace/diag_fisher.py
@@ -1,8 +1,9 @@
 from functools import partial
-from typing import Any, NamedTuple
+from typing import Any
 import torch
 from torch.func import jacrev
 from optree import tree_map
+from tensordict import tensorclass
 
 from posteriors.types import TensorTree, Transform, LogProbFn
 from posteriors.tree_utils import flexi_tree_map
@@ -53,7 +54,8 @@ def build(
     return Transform(init_fn, update_fn)
 
 
-class DiagLaplaceState(NamedTuple):
+@tensorclass(frozen=True)
+class DiagLaplaceState:
     """State encoding a diagonal Normal distribution over parameters.
 
     Attributes:
@@ -132,7 +134,7 @@ def update(
     )
 
     if inplace:
-        return state._replace(aux=aux)
+        return state.replace(aux=aux)
     return DiagLaplaceState(state.params, prec_diag, aux)
 
 

--- a/posteriors/laplace/diag_ggn.py
+++ b/posteriors/laplace/diag_ggn.py
@@ -1,7 +1,8 @@
 from functools import partial
-from typing import Any, NamedTuple
+from typing import Any
 import torch
 from optree import tree_map
+from tensordict import tensorclass
 
 from posteriors.types import (
     TensorTree,
@@ -64,7 +65,8 @@ def build(
     return Transform(init_fn, update_fn)
 
 
-class DiagLaplaceState(NamedTuple):
+@tensorclass(frozen=True)
+class DiagLaplaceState:
     """State encoding a diagonal Normal distribution over parameters.
 
     Attributes:
@@ -146,7 +148,7 @@ def update(
     )
 
     if inplace:
-        return state._replace(aux=aux)
+        return state.replace(aux=aux)
     return DiagLaplaceState(state.params, prec_diag, aux)
 
 

--- a/posteriors/optim.py
+++ b/posteriors/optim.py
@@ -1,6 +1,7 @@
-from typing import Type, Any, NamedTuple
+from typing import Type, Any
 from functools import partial
 import torch
+from tensordict import tensorclass
 
 from posteriors.types import TensorTree, Transform, LogProbFn
 from posteriors.utils import CatchAuxError
@@ -36,7 +37,8 @@ def build(
     return Transform(init_fn, update_fn)
 
 
-class OptimState(NamedTuple):
+@tensorclass(frozen=True)
+class OptimState:
     """State of an optimizer from [torch.optim](https://pytorch.org/docs/stable/optim.html).
 
     Attributes:
@@ -48,7 +50,7 @@ class OptimState(NamedTuple):
 
     params: TensorTree
     optimizer: torch.optim.Optimizer
-    loss: torch.tensor = torch.tensor([])
+    loss: torch.Tensor = torch.tensor([])
     aux: Any = None
 
 
@@ -104,4 +106,4 @@ def update(
     loss.backward()
     state.optimizer.step()
     tree_insert_(state.loss, loss.detach())
-    return state._replace(aux=aux)
+    return state.replace(aux=aux)

--- a/posteriors/sgmcmc/sghmc.py
+++ b/posteriors/sgmcmc/sghmc.py
@@ -1,8 +1,9 @@
-from typing import Any, NamedTuple
+from typing import Any
 from functools import partial
 import torch
 from torch.func import grad_and_value
 from optree import tree_map
+from tensordict import tensorclass
 
 from posteriors.types import TensorTree, Transform, LogProbFn
 from posteriors.tree_utils import flexi_tree_map, tree_insert_
@@ -64,7 +65,8 @@ def build(
     return Transform(init_fn, update_fn)
 
 
-class SGHMCState(NamedTuple):
+@tensorclass(frozen=True)
+class SGHMCState:
     """State encoding params and momenta for SGHMC.
 
     Attributes:
@@ -76,7 +78,7 @@ class SGHMCState(NamedTuple):
 
     params: TensorTree
     momenta: TensorTree
-    log_posterior: torch.tensor = torch.tensor([])
+    log_posterior: torch.Tensor = torch.tensor([])
     aux: Any = None
 
 
@@ -164,5 +166,5 @@ def update(
 
     if inplace:
         tree_insert_(state.log_posterior, log_post.detach())
-        return state._replace(aux=aux)
+        return state.replace(aux=aux)
     return SGHMCState(params, momenta, log_post.detach(), aux)

--- a/posteriors/sgmcmc/sgld.py
+++ b/posteriors/sgmcmc/sgld.py
@@ -1,7 +1,8 @@
-from typing import Any, NamedTuple
+from typing import Any
 from functools import partial
 import torch
 from torch.func import grad_and_value
+from tensordict import tensorclass
 
 from posteriors.types import TensorTree, Transform, LogProbFn
 from posteriors.tree_utils import flexi_tree_map, tree_insert_
@@ -48,7 +49,8 @@ def build(
     return Transform(init, update_fn)
 
 
-class SGLDState(NamedTuple):
+@tensorclass(frozen=True)
+class SGLDState:
     """State encoding params for SGLD.
 
     Attributes:
@@ -58,7 +60,7 @@ class SGLDState(NamedTuple):
     """
 
     params: TensorTree
-    log_posterior: torch.tensor = torch.tensor([])
+    log_posterior: torch.Tensor = torch.tensor([])
     aux: Any = None
 
 
@@ -120,5 +122,5 @@ def update(
 
     if inplace:
         tree_insert_(state.log_posterior, log_post.detach())
-        return state._replace(aux=aux)
+        return state.replace(aux=aux)
     return SGLDState(params, log_post.detach(), aux)

--- a/posteriors/sgmcmc/sgnht.py
+++ b/posteriors/sgmcmc/sgnht.py
@@ -1,10 +1,10 @@
-from typing import Any, NamedTuple
+from typing import Any
 from functools import partial
 import torch
 from torch.func import grad_and_value
 from optree import tree_map
 from optree.integration.torch import tree_ravel
-
+from tensordict import tensorclass
 from posteriors.types import TensorTree, Transform, LogProbFn
 from posteriors.tree_utils import flexi_tree_map, tree_insert_
 from posteriors.utils import is_scalar, CatchAuxError
@@ -67,7 +67,8 @@ def build(
     return Transform(init_fn, update_fn)
 
 
-class SGNHTState(NamedTuple):
+@tensorclass(frozen=True)
+class SGNHTState:
     """State encoding params and momenta for SGNHT.
 
     Attributes:
@@ -79,8 +80,8 @@ class SGNHTState(NamedTuple):
 
     params: TensorTree
     momenta: TensorTree
-    xi: torch.tensor = torch.tensor([])
-    log_posterior: torch.tensor = torch.tensor([])
+    xi: torch.Tensor = torch.tensor([])
+    log_posterior: torch.Tensor = torch.tensor([])
     aux: Any = None
 
 
@@ -177,5 +178,5 @@ def update(
     if inplace:
         tree_insert_(state.xi, xi_new)
         tree_insert_(state.log_posterior, log_post.detach())
-        return state._replace(aux=aux)
+        return state.replace(aux=aux)
     return SGNHTState(params, momenta, xi_new, log_post.detach(), aux)

--- a/posteriors/torchopt.py
+++ b/posteriors/torchopt.py
@@ -1,7 +1,8 @@
-from typing import Any, NamedTuple
+from typing import Any
 from functools import partial
 import torch
 import torchopt
+from tensordict import tensorclass
 
 from posteriors.types import TensorTree, Transform, LogProbFn
 from posteriors.utils import CatchAuxError
@@ -37,7 +38,8 @@ def build(
     return Transform(init_fn, update_fn)
 
 
-class TorchOptState(NamedTuple):
+@tensorclass(frozen=True)
+class TorchOptState:
     """State of a [TorchOpt](https://github.com/metaopt/torchopt) optimizer.
 
     Contains the parameters, the optimizer state for the TorchOpt optimizer,
@@ -52,7 +54,7 @@ class TorchOptState(NamedTuple):
 
     params: TensorTree
     opt_state: torchopt.typing.OptState
-    loss: torch.tensor = torch.tensor([])
+    loss: torch.Tensor = torch.tensor([])
     aux: Any = None
 
 
@@ -108,6 +110,6 @@ def update(
     params = torchopt.apply_updates(params, updates, inplace=inplace)
     if inplace:
         tree_insert_(state.loss, loss.detach())
-        return state._replace(aux=aux)
+        return state.replace(aux=aux)
 
     return TorchOptState(params, opt_state, loss, aux)

--- a/posteriors/vi/dense.py
+++ b/posteriors/vi/dense.py
@@ -1,10 +1,11 @@
-from typing import Callable, Any, Tuple, NamedTuple
+from typing import Callable, Any, Tuple
 from functools import partial
 import torch
 from torch.func import grad_and_value, vmap
 from optree import tree_map
 from optree.integration.torch import tree_ravel
 import torchopt
+from tensordict import tensorclass
 
 from posteriors.types import TensorTree, Transform, LogProbFn
 from posteriors.tree_utils import tree_size, tree_insert_
@@ -61,7 +62,8 @@ def build(
     return Transform(init_fn, update_fn)
 
 
-class VIDenseState(NamedTuple):
+@tensorclass(frozen=True)
+class VIDenseState:
     """State encoding a diagonal Normal variational distribution over parameters.
 
     Attributes:
@@ -78,7 +80,7 @@ class VIDenseState(NamedTuple):
     params: TensorTree
     L_factor: torch.Tensor
     opt_state: torchopt.typing.OptState
-    nelbo: torch.tensor = torch.tensor([])
+    nelbo: torch.Tensor = torch.tensor([])
     aux: Any = None
 
 
@@ -170,7 +172,7 @@ def update(
 
     if inplace:
         tree_insert_(state.nelbo, nelbo_val.detach())
-        return state._replace(aux=aux)
+        return state.replace(aux=aux)
 
     return VIDenseState(mean, L_factor, opt_state, nelbo_val.detach(), aux)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Mathematics",
     "License :: OSI Approved :: Apache Software License",
 ]
-dependencies = ["torch>=2.0.0", "torchopt>=0.7.3", "optree>=0.10.0"]
+dependencies = ["torch>=2.0.0", "torchopt>=0.7.3", "optree>=0.10.0", "tensordict>=0.7.0"]
 
 [project.optional-dependencies]
 test = ["pre-commit", "pytest-cov", "pytest-xdist", "ruff"]


### PR DESCRIPTION
Fixes #83 

`NamedTuple` don't work nicely with `vmap`, this PR  adds [TensorDict](https://github.com/pytorch/tensordict) as a dependency and changes all algorithm states to be `tensorclass` which do work with `vmap` and also inherit all the nice properties of TensorDict such as device handling etc.