### PR TITLE
fix sglrw for dict params and multi dim tensors

### DIFF
--- a/posteriors/sgmcmc/sglrw.py
+++ b/posteriors/sgmcmc/sglrw.py
@@ -93,7 +93,7 @@ def update(
     T_val = temperature(state.step) if callable(temperature) else temperature
     # Spatial stepsize to make update binary
     diffusion_val = (2.0 * T_val) ** 0.5
-    delta_x = lr_val ** 0.5 * diffusion_val
+    delta_x = lr_val**0.5 * diffusion_val
 
     # Per-parameter binary LRW transform
     def transform_params(p, g):
@@ -134,7 +134,9 @@ def ternary_probs(
     Returns:
         Update probabilities as a tensor, with last axis being [p_minus, p_zero, p_plus].
     """
-    diffusion_val = torch.as_tensor(diffusion_val, dtype=drift_val.dtype, device=drift_val.device)
+    diffusion_val = torch.as_tensor(
+        diffusion_val, dtype=drift_val.dtype, device=drift_val.device
+    )
     stepsize = torch.as_tensor(stepsize, dtype=drift_val.dtype, device=drift_val.device)
     delta_x = torch.as_tensor(delta_x, dtype=drift_val.dtype, device=drift_val.device)
     desired_mean = stepsize * drift_val

--- a/posteriors/sgmcmc/sglrw.py
+++ b/posteriors/sgmcmc/sglrw.py
@@ -91,18 +91,13 @@ def update(
     # Resolve schedules
     lr_val = lr(state.step) if callable(lr) else lr
     T_val = temperature(state.step) if callable(temperature) else temperature
-    lr_val = torch.as_tensor(
-        lr_val, dtype=state.params.dtype, device=state.params.device
-    )
-    T_val = torch.as_tensor(T_val, dtype=state.params.dtype, device=state.params.device)
-
     # Spatial stepsize to make update binary
-    diffusion_val = torch.sqrt(2.0 * T_val)
-    delta_x = torch.sqrt(lr_val) * diffusion_val
+    diffusion_val = (2.0 * T_val) ** 0.5
+    delta_x = lr_val ** 0.5 * diffusion_val
 
     # Per-parameter binary LRW transform
     def transform_params(p, g):
-        p_plus = ternary_probs(g, diffusion_val, lr_val, delta_x)[:, 2]
+        p_plus = ternary_probs(g, diffusion_val, lr_val, delta_x)[..., 2]
 
         u = torch.rand_like(p_plus)
         step_sign = torch.where(
@@ -139,6 +134,9 @@ def ternary_probs(
     Returns:
         Update probabilities as a tensor, with last axis being [p_minus, p_zero, p_plus].
     """
+    diffusion_val = torch.as_tensor(diffusion_val, dtype=drift_val.dtype, device=drift_val.device)
+    stepsize = torch.as_tensor(stepsize, dtype=drift_val.dtype, device=drift_val.device)
+    delta_x = torch.as_tensor(delta_x, dtype=drift_val.dtype, device=drift_val.device)
     desired_mean = stepsize * drift_val
     desired_var = stepsize * diffusion_val**2
     scaled_mean = desired_mean / delta_x

--- a/tests/sgmcmc/test_baoa.py
+++ b/tests/sgmcmc/test_baoa.py
@@ -40,7 +40,7 @@ def test_baoa_inplace_step():
     # Build transform
     transform = baoa.build(log_prob, lr)
 
-    # Initialise 
+    # Initialise
     params = {"w": torch.randn(2, 2), "b": torch.randn(1)}
 
     # Verify inplace update

--- a/tests/sgmcmc/test_baoa.py
+++ b/tests/sgmcmc/test_baoa.py
@@ -40,8 +40,8 @@ def test_baoa_inplace_step():
     # Build transform
     transform = baoa.build(log_prob, lr)
 
-    # Initialise
-    params = torch.randn(dim)
+    # Initialise 
+    params = {"w": torch.randn(2, 2), "b": torch.randn(1)}
 
     # Verify inplace update
     verify_inplace_update(transform, params, None)

--- a/tests/sgmcmc/test_sghmc.py
+++ b/tests/sgmcmc/test_sghmc.py
@@ -48,7 +48,7 @@ def test_sghmc_inplace_step():
     # Build transform
     transform = sghmc.build(log_prob, lr)
 
-    # Initialise 
+    # Initialise
     params = {"w": torch.randn(2, 2), "b": torch.randn(1)}
 
     # Verify inplace update

--- a/tests/sgmcmc/test_sghmc.py
+++ b/tests/sgmcmc/test_sghmc.py
@@ -48,8 +48,8 @@ def test_sghmc_inplace_step():
     # Build transform
     transform = sghmc.build(log_prob, lr)
 
-    # Initialise
-    params = torch.randn(dim)
+    # Initialise 
+    params = {"w": torch.randn(2, 2), "b": torch.randn(1)}
 
     # Verify inplace update
     verify_inplace_update(transform, params, None)

--- a/tests/sgmcmc/test_sgld.py
+++ b/tests/sgmcmc/test_sgld.py
@@ -33,7 +33,7 @@ def test_sgld_inplace_step():
     # Build transform
     transform = sgld.build(log_prob, lr)
 
-    # Initialise 
+    # Initialise
     params = {"w": torch.randn(2, 2), "b": torch.randn(1)}
 
     # Verify inplace update

--- a/tests/sgmcmc/test_sgld.py
+++ b/tests/sgmcmc/test_sgld.py
@@ -33,8 +33,8 @@ def test_sgld_inplace_step():
     # Build transform
     transform = sgld.build(log_prob, lr)
 
-    # Initialise
-    params = torch.randn(dim)
+    # Initialise 
+    params = {"w": torch.randn(2, 2), "b": torch.randn(1)}
 
     # Verify inplace update
     verify_inplace_update(transform, params, None)

--- a/tests/sgmcmc/test_sglrw.py
+++ b/tests/sgmcmc/test_sglrw.py
@@ -32,7 +32,7 @@ def test_sglrw_inplace_step():
     # Build transform
     transform = sglrw.build(log_prob, lr)
 
-    # Initialise 
+    # Initialise
     params = {"w": torch.randn(2, 2), "b": torch.randn(1)}
 
     # Verify inplace update

--- a/tests/sgmcmc/test_sglrw.py
+++ b/tests/sgmcmc/test_sglrw.py
@@ -32,8 +32,8 @@ def test_sglrw_inplace_step():
     # Build transform
     transform = sglrw.build(log_prob, lr)
 
-    # Initialise
-    params = torch.randn(dim)
+    # Initialise 
+    params = {"w": torch.randn(2, 2), "b": torch.randn(1)}
 
     # Verify inplace update
     verify_inplace_update(transform, params, None)

--- a/tests/sgmcmc/test_sgnht.py
+++ b/tests/sgmcmc/test_sgnht.py
@@ -48,8 +48,8 @@ def test_sgnht_inplace_step():
     # Build transform
     transform = sgnht.build(log_prob, lr)
 
-    # Initialise
-    params = torch.randn(dim)
+    # Initialise 
+    params = {"w": torch.randn(2, 2), "b": torch.randn(1)}
 
     # Verify inplace update
     verify_inplace_update(transform, params, None)

--- a/tests/sgmcmc/test_sgnht.py
+++ b/tests/sgmcmc/test_sgnht.py
@@ -48,7 +48,7 @@ def test_sgnht_inplace_step():
     # Build transform
     transform = sgnht.build(log_prob, lr)
 
-    # Initialise 
+    # Initialise
     params = {"w": torch.randn(2, 2), "b": torch.randn(1)}
 
     # Verify inplace update


### PR DESCRIPTION
state.params.dtype fails on OrderedDict. Moved scalar to tensor conversion into ternary_probs using drift_val.dtype/device.
ternary_probs(...)[: , 2] fails for multi dimensional parameters. Changed to [...,2]. Updated tests to cover dict params with multi dim tensors.